### PR TITLE
Add files via upload

### DIFF
--- a/package/libs/kasalua/Makefile
+++ b/package/libs/kasalua/Makefile
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=kasalua
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL=https://github.com/TheRootED24/kasalua.git
+PKG-BRANCH=openwrt
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2024-07-28
+
+PKG_SOURCE_VERSION:=8b8c3ef4ba7904a59ad93ad176dbad2244a1c94b
+
+PKG_MIRROR_HASH:=6bb74ecad467044c12cb364c067aebc2f857f40b1d94259ce89dd4187e85d911
+
+PKG_MAINTAINER:=hostle <TheRootED24@gmail.com>
+PKG_LICENSE:=MIT License
+
+PKG_BUILD_FLAGS:=lto
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/kasalua
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=OpenWrt kasalua provides high level lua binding to the Kasa C interface library with minimal overhead
+  DEPENDS:=+liblua +lua
+endef
+
+TARGET_CFLAGS += -std=gnu99 -I$(STAGING_DIR)/usr/include/kasalua/
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/kasalua
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/*.h \
+		$(1)/usr/include/kasalua/
+
+	$(INSTALL_DIR) $(1)/usr/lib/lua/kasalua
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/kasa.so* \
+		$(1)/usr/lib/lua/kasalua/
+	
+endef
+
+define Package/kasalua/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/kasalua
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipkg-install/usr/lib/lua/kasa/kasa.so* $(1)/usr/lib/lua/kasalua/
+endef
+
+$(eval $(call BuildPackage,kasalua))

--- a/package/libs/mgjson/Makefile
+++ b/package/libs/mgjson/Makefile
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mgjson
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL=https://github.com/TheRootED24/mgjson.git
+PKG-BRANCH=openwrt
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2024-08-13
+			
+PKG_SOURCE_VERSION:=2dc18a96e6ecefb60bd00e75736fbbebefe74ba7
+
+PKG_MIRROR_HASH:=ad53bb5bb663012c35456bcbac115e16662984acc6368418d402036bc5453fb9
+
+PKG_MAINTAINER:=hostle <TheRootED24@gmail.com>
+PKG_LICENSE:=MIT License
+
+PKG_BUILD_FLAGS:=lto
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/mgjson
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Stripped down OpenWrt version of Mongoose C Networking built as a shared Library
+endef
+
+TARGET_CFLAGS += -std=gnu99 -I$(STAGING_DIR)/usr/include/mgjson/
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/mgjson
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/*.h \
+		$(1)/usr/include/mgjson/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/libmgjson.so \
+		$(1)/usr/lib/
+	
+endef
+
+define Package/mgjson/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipkg-install/usr/lib/libmgjson.so $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,mgjson))

--- a/package/libs/mongoose/Makefile
+++ b/package/libs/mongoose/Makefile
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mongoose
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL=https://github.com/TheRootED24/libmongoose.git
+PKG-BRANCH=openwrt
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2024-07-28
+			
+PKG_SOURCE_VERSION:=fbb294824e06e33028922dc39843ac05a162ebd7
+
+PKG_MIRROR_HASH:=de68883299c947b0513c66f082fc33db72c773d8dac5b8b61385abcd1fc6117a
+
+PKG_MAINTAINER:=hostle <TheRootED24@gmail.com>
+PKG_LICENSE:=MIT License
+
+PKG_BUILD_FLAGS:=lto
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/mongoose
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=OpenWrt Mongoose C Networking shared Library
+  DEPENDS:=+libopenssl
+endef
+
+TARGET_CFLAGS += -std=gnu99 -I$(STAGING_DIR)/usr/include/mongoose/
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/mongoose
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/*.h \
+		$(1)/usr/include/mongoose/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/libmongoose.so* \
+		$(1)/usr/lib/
+	
+endef
+
+define Package/mongoose/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipkg-install/usr/lib/libmongoose.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,mongoose))

--- a/package/utils/jsonmg/Makefile
+++ b/package/utils/jsonmg/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=jsonmg
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL=https://github.com/TheRootED24/jsonmg.git
+PKG-BRANCH=openwrt
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2024-08-15
+			
+PKG_SOURCE_VERSION:=6a1d6b78bc736ac680c9b0bb4b0a873ef92ba70d
+
+PKG_MIRROR_HASH:=bc63690b7e63f27ca73ea9e3802a9b57226bf632f5000b37ce8c7b0f26008698
+
+PKG_MAINTAINER:=hostle <TheRootED24@gmail.com>
+PKG_LICENSE:=GPLv3 License
+
+PKG_BUILD_FLAGS:=lto
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/jsonmg
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:= A basic JSON parsing and serialization library. 
+  DEPENDS:=+mgjson +liblua
+endef
+
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/mgjson/
+
+define Package/jsonmg/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/jsonmg
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipkg-install/usr/lib/lua/jsonmg/jsonmg.so $(1)/usr/lib/lua/jsonmg
+endef
+
+$(eval $(call BuildPackage,jsonmg))


### PR DESCRIPTION
Add new packages

jsonmg - a high level lua binding to the Mongoose C Networking Library. It provide a JSON parser that parsing JSON notation into the representing lua form. It also provides stringify functionality that parsing lua into the representing JSON notation. 

mongoose - is merely a makefile to compile the Mongoose library as a Shared Library for linking against.

mgjson - is a stripped down version on the Mongoose library. It provides only the mg_json, mg_str, mg_iobuf functionality with out the overhead of all the networking functionallity of the complete mongoose C library.

kasalua - is a high level lua binding to the kasaC library, built to interact and control a vast number of the kasa smart home network devices .. plugs,strips, wall plugs, dimmers, smart bulbs and lightstrips ..etc

I have tested everything i have included against the 23.05.3 branch. Every thing compiles and builds without errors or warnings. -Werror is set in every makefile.

Valgrind reports 0 errors 0 bytes in use at exit. 

any question, concerns and proposed changes are welcome

TheRootED
