### PR TITLE
add function to generate images compatible with GL.iNET u-boot recovery

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -590,14 +590,14 @@ endef
 
 define Build/qsdk-ipq-factory-nand
 	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh \
-		$@.its ubi $@
+		$@.its ubi firmware $@
 	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
 	@mv $@.new $@
 endef
 
 define Build/qsdk-ipq-factory-nor
 	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh \
-		$@.its hlos $(IMAGE_KERNEL) rootfs $(IMAGE_ROOTFS)
+		$@.its hlos firmware $(IMAGE_KERNEL) rootfs firmware $(IMAGE_ROOTFS)
 	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
 	@mv $@.new $@
 endef

--- a/scripts/mkits-qsdk-ipq-image.sh
+++ b/scripts/mkits-qsdk-ipq-image.sh
@@ -15,12 +15,12 @@
 #
 
 usage() {
-	echo "Usage: `basename $0` output img0_name img0_file [[img1_name img1_file] ...]"
+	echo "Usage: `basename $0` output img0_name img0_type img0_file [[img1_name img1_type img1_file] ...]"
 	exit 1
 }
 
-# We need at least 3 arguments
-[ "$#" -lt 3 ] && usage
+# We need at least 4 arguments
+[ "$#" -lt 4 ] && usage
 
 # Target output file
 OUTPUT="$1"; shift
@@ -35,18 +35,23 @@ echo "\
 
 	images {" > ${OUTPUT}
 
-while [ -n "$1" -a -n "$2" ]; do
-	[ -f "$2" ] || usage
+while [ -n "$1" -a -n "$2" -a -n "$3" ]; do
+	[ -f "$3" ] || usage
 
 	name="$1"; shift
+	img_type="$1"; shift
 	file="$1"; shift
+	arch=""
 
+	if [ "$img_type" = "firmware" ]; then
+		arch="
+			arch = \"arm\";"
+	fi
 	echo \
 "		${name} {
 			description = \"${name}\";
 			data = /incbin/(\"${file}\");
-			type = \"Firmware\";
-			arch = \"ARM\";
+			type = \"${img_type}\";${arch}
 			compression = \"none\";
 			hash@1 {
 				algo = \"crc32\";

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -95,9 +95,9 @@ endef
 
 define Build/qsdk-ipq-factory-nand-askey
 	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh $@.its\
-		askey_kernel $@.$1 \
-		askey_fs $(IMAGE_ROOTFS) \
-		ubifs $@
+		askey_kernel firmware $@.$1 \
+		askey_fs firmware $(IMAGE_ROOTFS) \
+		ubifs firmware $@
 	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
 	@mv $@.new $@
 endef

--- a/target/linux/qualcommax/image/Makefile
+++ b/target/linux/qualcommax/image/Makefile
@@ -1,6 +1,15 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
+define Build/qsdk-ipq-factory-nand-glinet
+	./gen_$(BOOT_SCRIPT)_bootscript.sh $@
+	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh $@.its \
+		script script $@.bootscript \
+		ubi firmware $@
+	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
+	@mv $@.new $@
+endef
+
 define Device/Default
 	PROFILES := Default
 	KERNEL_LOADADDR := 0x41000000


### PR DESCRIPTION
The FIT format allows for many different types of images. Adding options to specify the image type allows for the generation of more complex images.

U-boot recovery on GL.iNET devices supports FIT images with additional script. New qsdk-ipq-factory-nand-glinet function allows generating such images.

The ability to generate a bootscript with changes inside has been added.
